### PR TITLE
Fix：UIImage scale error!

### DIFF
--- a/ios/Classes/UIImageHandler.m
+++ b/ios/Classes/UIImageHandler.m
@@ -25,7 +25,7 @@ void UIImageHandler(NSString* method, id rawArgs, FlutterResult methodResult) {
         
         FlutterStandardTypedData* bitmapBytes = (FlutterStandardTypedData*) args[@"bitmapBytes"];
         
-        UIImage *bitmap = [UIImage imageWithData:bitmapBytes.data];
+        UIImage *bitmap = [UIImage imageWithData:bitmapBytes.data scale:[UIScreen mainScreen].scale];
         
         HEAP[@(bitmap.hash)] = bitmap;
         
@@ -59,7 +59,7 @@ void UIImageHandler(NSString* method, id rawArgs, FlutterResult methodResult) {
 
             FlutterStandardTypedData* bitmapBytes = (FlutterStandardTypedData*) args[@"bitmapBytes"];
             
-            UIImage *bitmap = [UIImage imageWithData:bitmapBytes.data];
+            UIImage *bitmap = [UIImage imageWithData:bitmapBytes.data scale:[UIScreen mainScreen].scale];
             
             HEAP[@(bitmap.hash)] = bitmap;
         


### PR DESCRIPTION
on iphone device, If not set scale, bubble will so bigger, because it scale default one.