### PR TITLE
区分context 和 activity

### DIFF
--- a/android/src/main/kotlin/me/yohom/foundation_fluttify/FoundationFluttifyPlugin.kt
+++ b/android/src/main/kotlin/me/yohom/foundation_fluttify/FoundationFluttifyPlugin.kt
@@ -1,6 +1,7 @@
 package me.yohom.foundation_fluttify
 
 import android.app.Activity
+import android.content.Context
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -39,6 +40,7 @@ lateinit var gMethodChannel: MethodChannel
 lateinit var gBroadcastEventChannel: EventChannel
 
 class FoundationFluttifyPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
+    private var applicationContext: Context? = null
     private var activity: Activity? = null
     private var activityBinding: ActivityPluginBinding? = null
     private var pluginBinding: FlutterPlugin.FlutterPluginBinding? = null
@@ -62,7 +64,7 @@ class FoundationFluttifyPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
         val rawArgs = methodCall.arguments ?: mapOf<String, Any>()
         methodCall.method.run {
             when {
-                startsWith("android.app.Application::") -> ApplicationHandler(methodCall.method, rawArgs, methodResult, activity)
+                startsWith("android.app.Application::") -> ApplicationHandler(methodCall.method, rawArgs, methodResult, applicationContext)
                 startsWith("android.app.Activity::") -> ActivityHandler(methodCall.method, rawArgs, methodResult, activity)
                 startsWith("android.app.PendingIntent::") -> PendingIntentHandler(methodCall.method, rawArgs, methodResult)
                 startsWith("android.app.Notification::") -> NotificationHandler(methodCall.method, rawArgs, methodResult, activity)
@@ -81,7 +83,8 @@ class FoundationFluttifyPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
     }
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        pluginBinding = binding;
+        applicationContext = binding.applicationContext
+        pluginBinding = binding
 
         gMethodChannel = MethodChannel(binding.binaryMessenger, "com.fluttify/foundation_method")
         gMethodChannel.setMethodCallHandler(this)

--- a/android/src/main/kotlin/me/yohom/foundation_fluttify/android/app/ApplicationHandler.kt
+++ b/android/src/main/kotlin/me/yohom/foundation_fluttify/android/app/ApplicationHandler.kt
@@ -1,14 +1,15 @@
 package me.yohom.foundation_fluttify.android.app
 
 import android.app.Activity
+import android.content.Context
 import io.flutter.plugin.common.MethodChannel
 import me.yohom.foundation_fluttify.HEAP
 
-fun ApplicationHandler(method: String, args: Any, methodResult: MethodChannel.Result, context: Activity?) {
+fun ApplicationHandler(method: String, args: Any, methodResult: MethodChannel.Result, context: Context?) {
     when (method) {
         "android.app.Application::get" -> {
-            val hash = System.identityHashCode(context?.application)
-            HEAP[hash] = context?.application!!
+            val hash = System.identityHashCode(context)
+            HEAP[hash] = context!!
             methodResult.success(hash)
         }
         else -> methodResult.notImplemented()


### PR DESCRIPTION
后台运行FLutterEngine时，没有activity，但有context。
为了解决纯后台定位时context空的问题。